### PR TITLE
Improve stability of non-configured plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Example configuration:
           "name": "Battery",
           "model": "Delta 2 Max",
           "serialNumber": "R123ABCDEGHI321",
+          "location": "EU",
           "accessKey": "IROcwtlejtHj4qY4MRgCZW0CxoCdPVs3",
           "secretKey": "yBwYgZWqNnAlULKmF1Qrydy2Iheexj22"
         }

--- a/config.schema.json
+++ b/config.schema.json
@@ -36,6 +36,14 @@
               "required": true,
               "description": "Serial number of the EcoFlow device"
             },
+            "location": {
+              "title": "Location",
+              "type": "string",
+              "default": "EU",
+              "required": true,
+              "enum": ["EU", "US"],
+              "description": "API host depends on device's location (EU: api-e.ecoflow.com, US: api-a.ecoflow.com)"
+            },
             "accessKey": {
               "title": "Access Key",
               "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Ecoflow",
   "name": "@pietrolubini/homebridge-ecoflow",
-  "version": "1.2.0-beta",
+  "version": "1.2.1-beta",
   "description": "Homebridge plugin for EcoFlow devices",
   "license": "MIT",
   "author": "PietroLubini",

--- a/src/accessories/ecoFlowAccessory.ts
+++ b/src/accessories/ecoFlowAccessory.ts
@@ -79,6 +79,10 @@ export abstract class EcoFlowAccessory {
   protected processSetReplyMessage(message: MqttSetReplyMessage): void {
     const messageKey = this.getMqttSetMessageKey(message);
     const command = this.setReplies[messageKey];
+    if (!command) {
+      this.log.debug('Received "SetReply" response was sent from another instance of homebridge. Ignore it:', message);
+      return;
+    }
     delete this.setReplies[messageKey];
     if (message.data.ack) {
       this.log.warn('Failed to set a value. Reverts value back for:', command.requestMessage.operateType);

--- a/src/accessories/ecoFlowAccessory.ts
+++ b/src/accessories/ecoFlowAccessory.ts
@@ -141,7 +141,9 @@ export abstract class EcoFlowAccessoryWithQuota<TAllQuotaData> extends EcoFlowAc
       this._quota = await this.httpApi.getAllQuotas<TAllQuotaData>();
     }
     await super.initialize();
-    this.updateInitialValues(this._quota);
+    if (this._quota) {
+      this.updateInitialValues(this._quota);
+    }
   }
 
   public get quota(): TAllQuotaData {

--- a/src/apis/ecoFlowHttpApi.ts
+++ b/src/apis/ecoFlowHttpApi.ts
@@ -1,8 +1,9 @@
 import * as crypto from 'crypto';
 import { Logging } from 'homebridge';
-import { DeviceConfig } from '../config.js';
+import { DeviceConfig, LocationType } from '../config.js';
 
-const ApiUrl = 'https://api-e.ecoflow.com';
+const ApiUrlUs = 'https://api-a.ecoflow.com';
+const ApiUrlEu = 'https://api-e.ecoflow.com';
 const QuotaPath = '/iot-open/sign/device/quota';
 const QuotaAllPath = '/iot-open/sign/device/quota/all';
 const CertificatePath = '/iot-open/sign/certification';
@@ -50,10 +51,13 @@ interface Dict {
 }
 
 export class EcoFlowHttpApi {
+  private readonly apiUrl: string;
   constructor(
     private readonly config: DeviceConfig,
     private readonly log: Logging
-  ) {}
+  ) {
+    this.apiUrl = this.config.location === LocationType.US ? ApiUrlUs : ApiUrlEu;
+  }
 
   public async getQuotas<TData>(quotas: string[]): Promise<TData> {
     this.log.debug('Get quotas:', quotas);
@@ -101,7 +105,7 @@ export class EcoFlowHttpApi {
     queryParameters: object | null = null,
     body: object | null = null
   ): Promise<TResponse> {
-    const url = new URL(relativeUrl, ApiUrl);
+    const url = new URL(relativeUrl, this.apiUrl);
     const accessKey = this.config.accessKey;
     const nonce = this.getNonce();
     const timestamp = Date.now();

--- a/src/apis/ecoFlowHttpApi.ts
+++ b/src/apis/ecoFlowHttpApi.ts
@@ -72,7 +72,7 @@ export class EcoFlowHttpApi {
     return {} as TData;
   }
 
-  public async getAllQuotas<TData>(): Promise<TData> {
+  public async getAllQuotas<TData>(): Promise<TData | null> {
     this.log.debug('Get all quotas');
     const requestCmd: GetCmdRequest = {
       sn: this.config.serialNumber,
@@ -83,7 +83,7 @@ export class EcoFlowHttpApi {
       this.log.debug('All quotas:', data);
       return data;
     }
-    return {} as TData;
+    return null;
   }
 
   public async acquireCertificate(): Promise<AcquireCertificateData | null> {

--- a/src/characteristics/CustomCharacteristic.ts
+++ b/src/characteristics/CustomCharacteristic.ts
@@ -1,85 +1,94 @@
-import { Characteristic } from 'hap-nodejs';
-import { Formats, Perms, Units } from 'homebridge';
+import { Characteristic, Formats, HAP, Perms, Units, WithUUID } from 'homebridge';
 
-export class InputConsumptionWatt extends Characteristic {
-  public static readonly UUID: string = '13172B0A-D346-4730-9732-32EF5B6EF8B7';
-  constructor() {
-    super('Input Consumption', InputConsumptionWatt.UUID, {
-      description: 'Input Consumption, W',
-      format: Formats.FLOAT,
-      perms: [Perms.NOTIFY, Perms.PAIRED_READ],
-      minValue: 0,
-      minStep: 1,
-      unit: Units.CELSIUS, // To allow setting numeric value for conditions in ShortCuts
-    });
-    this.value = this.getDefaultValue();
-  }
-}
+export const InputConsumptionWattFactory = (hap: HAP): WithUUID<{ new (): Characteristic }> => {
+  return class InputConsumptionWatt extends hap.Characteristic {
+    public static readonly UUID: string = '13172B0A-D346-4730-9732-32EF5B6EF8B7';
+    constructor() {
+      super('Input Consumption', InputConsumptionWatt.UUID, {
+        description: 'Input Consumption, W',
+        format: Formats.FLOAT,
+        perms: [Perms.NOTIFY, Perms.PAIRED_READ],
+        minValue: 0,
+        minStep: 1,
+        unit: Units.CELSIUS, // To allow setting numeric value for conditions in ShortCuts
+      });
+      this.value = this.getDefaultValue();
+    }
+  };
+};
 
-export class OutputConsumptionWatt extends Characteristic {
-  // Eve characteristic
-  public static readonly UUID: string = 'E863F10D-079E-48FF-8F27-9C2605A29F52';
-  constructor() {
-    super('Output Consumption', OutputConsumptionWatt.UUID, {
-      description: 'Output Consumption, W',
-      format: Formats.FLOAT,
-      perms: [Perms.NOTIFY, Perms.PAIRED_READ],
-      unit: Units.CELSIUS, // To allow setting numeric value for conditions in ShortCuts
-      minValue: 0,
-      minStep: 1,
-    });
-    this.value = this.getDefaultValue();
-  }
-}
+export const OutputConsumptionWattFactory = (hap: HAP): WithUUID<{ new (): Characteristic }> => {
+  return class OutputConsumptionWatt extends hap.Characteristic {
+    // Eve characteristic
+    public static readonly UUID: string = 'E863F10D-079E-48FF-8F27-9C2605A29F52';
+    constructor() {
+      super('Output Consumption', OutputConsumptionWatt.UUID, {
+        description: 'Output Consumption, W',
+        format: Formats.FLOAT,
+        perms: [Perms.NOTIFY, Perms.PAIRED_READ],
+        unit: Units.CELSIUS, // To allow setting numeric value for conditions in ShortCuts
+        minValue: 0,
+        minStep: 1,
+      });
+      this.value = this.getDefaultValue();
+    }
+  };
+};
 
 // https://gist.github.com/simont77/3f4d4330fa55b83f8ca96388d9004e7d
-// export class PowerConsumptionVolt extends Characteristic {
-//   public static readonly UUID: string = 'E863F10A-079E-48FF-8F27-9C2605A29F52';
-//   constructor() {
-//     super('Voltage', PowerConsumptionVolt.UUID, {
-//       description: '"Voltage, V" in Eve App',
-//       format: Formats.FLOAT,
-//       perms: [Perms.NOTIFY, Perms.PAIRED_READ],
-//       minValue: 0,
-//       maxValue: 300,
-//     });
-//     this.value = this.getDefaultValue();
-//   }
-// }
+// export const PowerConsumptionVoltFactory = (hap: HAP): WithUUID<{ new (): Characteristic }> => {
+//   return class PowerConsumptionVolt extends hap.Characteristic {
+//     public static readonly UUID: string = 'E863F10A-079E-48FF-8F27-9C2605A29F52';
+//     constructor() {
+//       super('Voltage', PowerConsumptionVolt.UUID, {
+//         description: '"Voltage, V" in Eve App',
+//         format: Formats.FLOAT,
+//         perms: [Perms.NOTIFY, Perms.PAIRED_READ],
+//         minValue: 0,
+//         maxValue: 300,
+//       });
+//       this.value = this.getDefaultValue();
+//     }
+//   };
+// };
 
-// export class PowerConsumptionAmpere extends Characteristic {
-//   public static readonly UUID: string = 'E863F126-079E-48FF-8F27-9C2605A29F52';
-//   constructor() {
-//     super('Current', PowerConsumptionAmpere.UUID, {
-//       description: '"Current, A" in Eve App',
-//       format: Formats.FLOAT,
-//       perms: [Perms.NOTIFY, Perms.PAIRED_READ],
-//       minValue: 0,
-//       maxValue: 100,
-//     });
-//     this.value = this.getDefaultValue();
-//   }
-// }
+// export const PowerConsumptionAmpereFactory = (hap: HAP): WithUUID<{ new (): Characteristic }> => {
+//   return class PowerConsumptionAmpere extends hap.Characteristic {
+//     public static readonly UUID: string = 'E863F126-079E-48FF-8F27-9C2605A29F52';
+//     constructor() {
+//       super('Current', PowerConsumptionAmpere.UUID, {
+//         description: '"Current, A" in Eve App',
+//         format: Formats.FLOAT,
+//         perms: [Perms.NOTIFY, Perms.PAIRED_READ],
+//         minValue: 0,
+//         maxValue: 100,
+//       });
+//       this.value = this.getDefaultValue();
+//     }
+//   };
+// };
 
-// export class PowerConsumptionKilowattHour extends Characteristic {
-//   public static readonly UUID: string = 'E863F10C-079E-48FF-8F27-9C2605A29F52';
-//   constructor() {
-//     super('Total Consumption', PowerConsumptionKilowattHour.UUID, {
-//       description: '"Total Consumption, kW/h" in Eve App',
-//       format: Formats.FLOAT,
-//       perms: [Perms.NOTIFY, Perms.PAIRED_READ],
-//       minValue: 0,
-//       maxValue: 50,
-//     });
-//     this.value = this.getDefaultValue();
-//   }
-// }
+// export const PowerConsumptionKilowattHourFactory = (hap: HAP): WithUUID<{ new (): Characteristic }> => {
+//   return class PowerConsumptionKilowattHour extends hap.Characteristic {
+//     public static readonly UUID: string = 'E863F10C-079E-48FF-8F27-9C2605A29F52';
+//     constructor() {
+//       super('Total Consumption', PowerConsumptionKilowattHour.UUID, {
+//         description: '"Total Consumption, kW/h" in Eve App',
+//         format: Formats.FLOAT,
+//         perms: [Perms.NOTIFY, Perms.PAIRED_READ],
+//         minValue: 0,
+//         maxValue: 50,
+//       });
+//       this.value = this.getDefaultValue();
+//     }
+//   };
+// };
 
 export class PowerConsumption {
-  public static readonly InputConsumptionWatts: typeof InputConsumptionWatt = InputConsumptionWatt;
-  public static readonly OutputConsumptionWatts: typeof OutputConsumptionWatt = OutputConsumptionWatt;
+  public static InputConsumptionWatts: WithUUID<{ new (): Characteristic }>;
+  public static OutputConsumptionWatts: WithUUID<{ new (): Characteristic }>;
 }
 
-export class CustomCharacteristic {
+export class CustomCharacteristics {
   public static readonly PowerConsumption: typeof PowerConsumption = PowerConsumption;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,9 +9,15 @@ export enum DeviceModel {
   Delta2 = 'Delta 2',
 }
 
+export enum LocationType {
+  EU = 'EU',
+  US = 'US',
+}
+
 export interface DeviceConfig extends AccessoryConfig {
   model: DeviceModel;
   serialNumber: string;
+  location: LocationType;
   accessKey: string;
   secretKey: string;
   battery?: BatteryDeviceConfig;


### PR DESCRIPTION
Resolves #8 
- Configuration is extended with `location` of device, from which depends API host
   - EU: https://api-e.ecoflow.com
   - US: https://api-a.ecoflow.com
- Fix bugs:
   - Ignore `set_reply` response for command that was not initialized by current instance of homebridge
   - Does not fail when all quotas could not be received (e.g. when api key is invalid)
   - Get rid of implicit `hap-nodejs` dependency