### PR TITLE
Delta Pro 3 > Cleanup X-Boost service

### DIFF
--- a/src/accessories/batteries/deltapro3/deltaPro3Accessory.spec.ts
+++ b/src/accessories/batteries/deltapro3/deltaPro3Accessory.spec.ts
@@ -389,15 +389,15 @@ describe('DeltaPro3Accessory', () => {
         expect(outletDc12vServiceMock.updateState).toHaveBeenCalledWith(true);
       });
 
-      it('should update X-Boost state when message is received with xboostEn', async () => {
-        const message: DeltaPro3AllQuotaData = {
-          xboostEn: AcXBoostType.On,
-        };
+      // it('should update X-Boost state when message is received with xboostEn', async () => {
+      //   const message: DeltaPro3AllQuotaData = {
+      //     xboostEn: AcXBoostType.On,
+      //   };
 
-        processQuotaMessage(message);
+      //   processQuotaMessage(message);
 
-        expect(switchXboostServiceMock.updateState).toHaveBeenCalledWith(true);
-      });
+      //   expect(switchXboostServiceMock.updateState).toHaveBeenCalledWith(true);
+      // });
 
       it('should not update any characteristic when message is received with undefined status', async () => {
         const message: DeltaPro3AllQuotaData = {};
@@ -523,7 +523,7 @@ describe('DeltaPro3Accessory', () => {
         expect(outletAcHvServiceMock.updateState).toHaveBeenCalledWith(true);
         expect(outletAcLvServiceMock.updateState).toHaveBeenCalledWith(false);
         expect(outletDc12vServiceMock.updateState).toHaveBeenCalledWith(false);
-        expect(switchXboostServiceMock.updateState).toHaveBeenCalledWith(false);
+        // expect(switchXboostServiceMock.updateState).toHaveBeenCalledWith(false);
       });
 
       it('should update switch-related characteristics when is requested and quotas were not initialized properly for it', async () => {

--- a/src/accessories/batteries/deltapro3/deltaPro3Accessory.ts
+++ b/src/accessories/batteries/deltapro3/deltaPro3Accessory.ts
@@ -6,8 +6,6 @@ import { DeltaPro3MqttQuotaMessage } from '@ecoflow/accessories/batteries/deltap
 import { OutletAcHvService } from '@ecoflow/accessories/batteries/deltapro3/services/outletAcHvService';
 import { OutletAcLvService } from '@ecoflow/accessories/batteries/deltapro3/services/outletAcLvService';
 import { OutletDc12vService } from '@ecoflow/accessories/batteries/deltapro3/services/outletDc12vService';
-import { SwitchXboostService } from '@ecoflow/accessories/batteries/deltapro3/services/switchXboostService';
-import { AcXBoostType } from '@ecoflow/accessories/batteries/interfaces/batteryHttpApiContracts';
 import { EcoFlowAccessoryWithQuotaBase } from '@ecoflow/accessories/ecoFlowAccessoryWithQuotaBase';
 import { EcoFlowHttpApiManager } from '@ecoflow/apis/ecoFlowHttpApiManager';
 import { EcoFlowMqttApiManager } from '@ecoflow/apis/ecoFlowMqttApiManager';
@@ -24,7 +22,7 @@ export class DeltaPro3Accessory extends EcoFlowAccessoryWithQuotaBase<DeltaPro3A
   private readonly outletAcHvService: OutletAcHvService;
   private readonly outletAcLvService: OutletAcLvService;
   private readonly outletDc12vService: OutletDc12vService;
-  private readonly switchXboostService: SwitchXboostService;
+  // private readonly switchXboostService: SwitchXboostService;
 
   constructor(
     platform: EcoFlowHomebridgePlatform,
@@ -40,7 +38,7 @@ export class DeltaPro3Accessory extends EcoFlowAccessoryWithQuotaBase<DeltaPro3A
     this.outletAcHvService = new OutletAcHvService(this, batteryStatusProvider);
     this.outletAcLvService = new OutletAcLvService(this, batteryStatusProvider);
     this.outletDc12vService = new OutletDc12vService(this, batteryStatusProvider);
-    this.switchXboostService = new SwitchXboostService(this);
+    // this.switchXboostService = new SwitchXboostService(this);
   }
 
   protected override getServices(): ServiceBase[] {
@@ -120,8 +118,8 @@ export class DeltaPro3Accessory extends EcoFlowAccessoryWithQuotaBase<DeltaPro3A
     if (params.flowInfo12v !== undefined && params.flowInfo12v !== DeltaPro3AcEnableType.Ignore) {
       this.outletDc12vService.updateState(params.flowInfo12v === DeltaPro3AcEnableType.On);
     }
-    if (params.xboostEn !== undefined && params.xboostEn !== AcXBoostType.Ignore) {
-      this.switchXboostService.updateState(params.xboostEn === AcXBoostType.On);
-    }
+    // if (params.xboostEn !== undefined && params.xboostEn !== AcXBoostType.Ignore) {
+    //   this.switchXboostService.updateState(params.xboostEn === AcXBoostType.On);
+    // }
   }
 }


### PR DESCRIPTION
Make sure that the pull request meets DoD criteria:

_Documentation_

- [x] Changes that makes documentation outdated are described in `README.md`

_Maintainability_

- [x] Reasonable amount of logging has been added (`Debug` level)
- [x] All errors are logged with `Error` level
- [x] Validation errors are logged with `Warning` level

_Testing_

- [x] Plugin does not crash when configuration is not provided (default state)
- [x] New functionality is dev tested in `Homebridge`
- [x] Errors that are produced by plugin do not crash `Homebridge`

Changes:
- Resolves #35
    - Stop crashing `Homebridge Bridge` when `Delta Pro 3` receives `xboostEn` in initial quota