### PR TITLE
Detect device is offline/online status

### DIFF
--- a/src/accessories/batteries/delta2/delta2AccessoryBase.spec.ts
+++ b/src/accessories/batteries/delta2/delta2AccessoryBase.spec.ts
@@ -148,8 +148,10 @@ describe('Delta2AccessoryBase', () => {
       destroy: jest.fn(),
       subscribeOnQuotaTopic: jest.fn(),
       subscribeOnSetReplyTopic: jest.fn(),
+      subscribeOnStatusTopic: jest.fn(),
       subscribeOnQuotaMessage: jest.fn(),
       subscribeOnSetReplyMessage: jest.fn(),
+      subscribeOnStatusMessage: jest.fn(),
       sendSetCommand: jest.fn(),
     } as unknown as jest.Mocked<EcoFlowMqttApiManager>;
     config = { secretKey: 'secretKey1', accessKey: 'accessKey1', serialNumber: 'sn1' } as unknown as DeviceConfig;
@@ -243,6 +245,7 @@ describe('Delta2AccessoryBase', () => {
       httpApiManagerMock.getAllQuotas.mockResolvedValueOnce(quota);
       mqttApiManagerMock.subscribeOnQuotaTopic.mockResolvedValue(true);
       mqttApiManagerMock.subscribeOnSetReplyTopic.mockResolvedValue(true);
+      mqttApiManagerMock.subscribeOnStatusTopic.mockResolvedValue(true);
     });
 
     describe('EmsStatus', () => {

--- a/src/accessories/batteries/deltapro/deltaProAccessory.spec.ts
+++ b/src/accessories/batteries/deltapro/deltaProAccessory.spec.ts
@@ -130,8 +130,10 @@ describe('DeltaProAccessory', () => {
       destroy: jest.fn(),
       subscribeOnQuotaTopic: jest.fn(),
       subscribeOnSetReplyTopic: jest.fn(),
+      subscribeOnStatusTopic: jest.fn(),
       subscribeOnQuotaMessage: jest.fn(),
       subscribeOnSetReplyMessage: jest.fn(),
+      subscribeOnStatusMessage: jest.fn(),
       sendSetCommand: jest.fn(),
     } as unknown as jest.Mocked<EcoFlowMqttApiManager>;
     config = { secretKey: 'secretKey1', accessKey: 'accessKey1', serialNumber: 'sn1' } as unknown as DeviceConfig;
@@ -169,6 +171,7 @@ describe('DeltaProAccessory', () => {
       httpApiManagerMock.getAllQuotas.mockResolvedValueOnce(quota);
       mqttApiManagerMock.subscribeOnQuotaTopic.mockResolvedValue(true);
       mqttApiManagerMock.subscribeOnSetReplyTopic.mockResolvedValue(true);
+      mqttApiManagerMock.subscribeOnStatusTopic.mockResolvedValue(true);
     });
 
     describe('BmsMasterStatus', () => {

--- a/src/accessories/batteries/deltapro3/deltaPro3Accessory.spec.ts
+++ b/src/accessories/batteries/deltapro3/deltaPro3Accessory.spec.ts
@@ -134,8 +134,10 @@ describe('DeltaPro3Accessory', () => {
       destroy: jest.fn(),
       subscribeOnQuotaTopic: jest.fn(),
       subscribeOnSetReplyTopic: jest.fn(),
+      subscribeOnStatusTopic: jest.fn(),
       subscribeOnQuotaMessage: jest.fn(),
       subscribeOnSetReplyMessage: jest.fn(),
+      subscribeOnStatusMessage: jest.fn(),
       sendSetCommand: jest.fn(),
     } as unknown as jest.Mocked<EcoFlowMqttApiManager>;
     config = { secretKey: 'secretKey1', accessKey: 'accessKey1', serialNumber: 'sn1' } as unknown as DeviceConfig;
@@ -174,6 +176,7 @@ describe('DeltaPro3Accessory', () => {
       httpApiManagerMock.getAllQuotas.mockResolvedValueOnce(quota);
       mqttApiManagerMock.subscribeOnQuotaTopic.mockResolvedValue(true);
       mqttApiManagerMock.subscribeOnSetReplyTopic.mockResolvedValue(true);
+      mqttApiManagerMock.subscribeOnStatusTopic.mockResolvedValue(true);
       await accessory.initialize();
       await accessory.initializeDefaultValues(false);
       processQuotaMessage = mqttApiManagerMock.subscribeOnQuotaMessage.mock.calls[0][1]!;

--- a/src/accessories/batteries/deltaproultra/deltaProUltraAccessory.spec.ts
+++ b/src/accessories/batteries/deltaproultra/deltaProUltraAccessory.spec.ts
@@ -123,8 +123,10 @@ describe('DeltaProUltraAccessory', () => {
       destroy: jest.fn(),
       subscribeOnQuotaTopic: jest.fn(),
       subscribeOnSetReplyTopic: jest.fn(),
+      subscribeOnStatusTopic: jest.fn(),
       subscribeOnQuotaMessage: jest.fn(),
       subscribeOnSetReplyMessage: jest.fn(),
+      subscribeOnStatusMessage: jest.fn(),
       sendSetCommand: jest.fn(),
     } as unknown as jest.Mocked<EcoFlowMqttApiManager>;
     config = { secretKey: 'secretKey1', accessKey: 'accessKey1', serialNumber: 'sn1' } as unknown as DeviceConfig;
@@ -161,6 +163,7 @@ describe('DeltaProUltraAccessory', () => {
       httpApiManagerMock.getAllQuotas.mockResolvedValueOnce(quota);
       mqttApiManagerMock.subscribeOnQuotaTopic.mockResolvedValue(true);
       mqttApiManagerMock.subscribeOnSetReplyTopic.mockResolvedValue(true);
+      mqttApiManagerMock.subscribeOnStatusTopic.mockResolvedValue(true);
     });
 
     describe('PdStatus', () => {

--- a/src/accessories/ecoFlowAccessoryBase.spec.ts
+++ b/src/accessories/ecoFlowAccessoryBase.spec.ts
@@ -2,7 +2,13 @@ import { EcoFlowAccessoryBase } from '@ecoflow/accessories/ecoFlowAccessoryBase'
 import { DeviceInfo } from '@ecoflow/apis/containers/deviceInfo';
 import { EcoFlowHttpApiManager } from '@ecoflow/apis/ecoFlowHttpApiManager';
 import { EcoFlowMqttApiManager } from '@ecoflow/apis/ecoFlowMqttApiManager';
-import { MqttQuotaMessage, MqttSetMessage, MqttSetReplyMessage } from '@ecoflow/apis/interfaces/mqttApiContracts';
+import {
+  MqttQuotaMessage,
+  MqttSetMessage,
+  MqttSetReplyMessage,
+  MqttStatusMessage,
+} from '@ecoflow/apis/interfaces/mqttApiContracts';
+import { EnableType } from '@ecoflow/characteristics/characteristicContracts';
 import { DeviceConfig } from '@ecoflow/config';
 import { BatteryStatusProvider } from '@ecoflow/helpers/batteryStatusProvider';
 import { getActualServices, MockService } from '@ecoflow/helpers/tests/accessoryTestHelper';
@@ -100,8 +106,10 @@ describe('EcoFlowAccessoryBase', () => {
       destroy: jest.fn(),
       subscribeOnQuotaTopic: jest.fn(),
       subscribeOnSetReplyTopic: jest.fn(),
+      subscribeOnStatusTopic: jest.fn(),
       subscribeOnQuotaMessage: jest.fn(),
       subscribeOnSetReplyMessage: jest.fn(),
+      subscribeOnStatusMessage: jest.fn(),
       sendSetCommand: jest.fn(),
     } as unknown as jest.Mocked<EcoFlowMqttApiManager>;
     batteryStatusProviderMock = {} as jest.Mocked<BatteryStatusProvider>;
@@ -137,6 +145,7 @@ describe('EcoFlowAccessoryBase', () => {
     it('should connect to mqtt server during initialization when subscription to quota and set_reply topic is successful', async () => {
       mqttApiManagerMock.subscribeOnQuotaTopic.mockResolvedValue(true);
       mqttApiManagerMock.subscribeOnSetReplyTopic.mockResolvedValue(true);
+      mqttApiManagerMock.subscribeOnStatusTopic.mockResolvedValue(true);
 
       await accessory.initialize();
       await waitMqttReconnection(1);
@@ -145,6 +154,8 @@ describe('EcoFlowAccessoryBase', () => {
       expect(mqttApiManagerMock.subscribeOnQuotaTopic).toHaveBeenCalledWith(deviceInfo);
       expect(mqttApiManagerMock.subscribeOnSetReplyTopic).toHaveBeenCalledTimes(1);
       expect(mqttApiManagerMock.subscribeOnSetReplyTopic).toHaveBeenCalledWith(deviceInfo);
+      expect(mqttApiManagerMock.subscribeOnStatusTopic).toHaveBeenCalledTimes(1);
+      expect(mqttApiManagerMock.subscribeOnStatusTopic).toHaveBeenCalledWith(deviceInfo);
     });
 
     it('should re-connect to mqtt server when subscription to quota was failed during initialization', async () => {
@@ -152,17 +163,35 @@ describe('EcoFlowAccessoryBase', () => {
         .mockImplementationOnce(() => Promise.resolve(false))
         .mockImplementationOnce(() => Promise.resolve(true));
       mqttApiManagerMock.subscribeOnSetReplyTopic.mockResolvedValue(true);
+      mqttApiManagerMock.subscribeOnStatusTopic.mockResolvedValue(true);
 
       await accessory.initialize();
       await waitMqttReconnection(1);
 
       expect(mqttApiManagerMock.subscribeOnQuotaTopic).toHaveBeenCalledTimes(2);
       expect(mqttApiManagerMock.subscribeOnSetReplyTopic).toHaveBeenCalledTimes(1);
+      expect(mqttApiManagerMock.subscribeOnStatusTopic).toHaveBeenCalledTimes(1);
     });
 
     it('should re-connect to mqtt server when subscription to set_reply was failed during initialization', async () => {
       mqttApiManagerMock.subscribeOnQuotaTopic.mockResolvedValue(true);
       mqttApiManagerMock.subscribeOnSetReplyTopic
+        .mockImplementationOnce(() => Promise.resolve(false))
+        .mockImplementationOnce(() => Promise.resolve(true));
+      mqttApiManagerMock.subscribeOnStatusTopic.mockResolvedValue(true);
+
+      await accessory.initialize();
+      await waitMqttReconnection(1);
+
+      expect(mqttApiManagerMock.subscribeOnQuotaTopic).toHaveBeenCalledTimes(2);
+      expect(mqttApiManagerMock.subscribeOnSetReplyTopic).toHaveBeenCalledTimes(2);
+      expect(mqttApiManagerMock.subscribeOnStatusTopic).toHaveBeenCalledTimes(1);
+    });
+
+    it('should re-connect to mqtt server when subscription to status was failed during initialization', async () => {
+      mqttApiManagerMock.subscribeOnQuotaTopic.mockResolvedValue(true);
+      mqttApiManagerMock.subscribeOnSetReplyTopic.mockResolvedValue(true);
+      mqttApiManagerMock.subscribeOnStatusTopic
         .mockImplementationOnce(() => Promise.resolve(false))
         .mockImplementationOnce(() => Promise.resolve(true));
 
@@ -171,19 +200,22 @@ describe('EcoFlowAccessoryBase', () => {
 
       expect(mqttApiManagerMock.subscribeOnQuotaTopic).toHaveBeenCalledTimes(2);
       expect(mqttApiManagerMock.subscribeOnSetReplyTopic).toHaveBeenCalledTimes(2);
+      expect(mqttApiManagerMock.subscribeOnStatusTopic).toHaveBeenCalledTimes(2);
     });
   });
 
   describe('subscribeOnParameterUpdates', () => {
     let quotaSubscriptionMock: jest.Mocked<Subscription>;
     let setReplySubscriptionMock: jest.Mocked<Subscription>;
+    let statusSubscriptionMock: jest.Mocked<Subscription>;
 
     beforeEach(() => {
       quotaSubscriptionMock = jest.fn() as unknown as jest.Mocked<Subscription>;
       setReplySubscriptionMock = jest.fn() as unknown as jest.Mocked<Subscription>;
+      statusSubscriptionMock = jest.fn() as unknown as jest.Mocked<Subscription>;
     });
 
-    it('should not subscribe on parameters updates for quota and set_reply messages when mqtt is failed to connect', async () => {
+    it('should not subscribe on parameters updates for quota, set_reply and status messages when mqtt is failed to connect', async () => {
       mqttApiManagerMock.subscribeOnQuotaTopic.mockResolvedValue(false);
 
       await accessory.initialize();
@@ -192,27 +224,33 @@ describe('EcoFlowAccessoryBase', () => {
       expect(actual).toEqual([]);
       expect(mqttApiManagerMock.subscribeOnQuotaMessage).not.toHaveBeenCalled();
       expect(mqttApiManagerMock.subscribeOnSetReplyMessage).not.toHaveBeenCalled();
+      expect(mqttApiManagerMock.subscribeOnStatusMessage).not.toHaveBeenCalled();
     });
 
-    it('should subscribe on parameters updates for quota and set_reply messages when mqtt is connected successfully', async () => {
+    it('should subscribe on parameters updates for quota, set_reply and status messages when mqtt is connected successfully', async () => {
       mqttApiManagerMock.subscribeOnQuotaTopic.mockResolvedValue(true);
       mqttApiManagerMock.subscribeOnSetReplyTopic.mockResolvedValue(true);
+      mqttApiManagerMock.subscribeOnStatusTopic.mockResolvedValue(true);
       mqttApiManagerMock.subscribeOnQuotaMessage.mockReturnValueOnce(quotaSubscriptionMock);
       mqttApiManagerMock.subscribeOnSetReplyMessage.mockReturnValueOnce(setReplySubscriptionMock);
+      mqttApiManagerMock.subscribeOnStatusMessage.mockReturnValueOnce(statusSubscriptionMock);
 
       await accessory.initialize();
       const actual = Reflect.get(accessory, 'subscriptions');
 
-      expect(actual).toEqual([quotaSubscriptionMock, setReplySubscriptionMock]);
+      expect(actual).toEqual([quotaSubscriptionMock, setReplySubscriptionMock, statusSubscriptionMock]);
       expect(mqttApiManagerMock.subscribeOnQuotaMessage).toHaveBeenCalledWith(deviceInfo, expect.any(Function));
       expect(mqttApiManagerMock.subscribeOnSetReplyMessage).toHaveBeenCalledWith(deviceInfo, expect.any(Function));
+      expect(mqttApiManagerMock.subscribeOnStatusMessage).toHaveBeenCalledWith(deviceInfo, expect.any(Function));
     });
 
     it('should filter failed subscription on parameters updates when mqtt is connected successfully', async () => {
       mqttApiManagerMock.subscribeOnQuotaTopic.mockResolvedValue(true);
       mqttApiManagerMock.subscribeOnSetReplyTopic.mockResolvedValue(true);
+      mqttApiManagerMock.subscribeOnStatusTopic.mockResolvedValue(true);
       mqttApiManagerMock.subscribeOnQuotaMessage.mockReturnValueOnce(undefined);
       mqttApiManagerMock.subscribeOnSetReplyMessage.mockReturnValueOnce(setReplySubscriptionMock);
+      mqttApiManagerMock.subscribeOnStatusMessage.mockReturnValueOnce(undefined);
 
       await accessory.initialize();
       const actual = Reflect.get(accessory, 'subscriptions');
@@ -220,6 +258,7 @@ describe('EcoFlowAccessoryBase', () => {
       expect(actual).toEqual([setReplySubscriptionMock]);
       expect(mqttApiManagerMock.subscribeOnQuotaMessage).toHaveBeenCalledWith(deviceInfo, expect.any(Function));
       expect(mqttApiManagerMock.subscribeOnSetReplyMessage).toHaveBeenCalledWith(deviceInfo, expect.any(Function));
+      expect(mqttApiManagerMock.subscribeOnStatusMessage).toHaveBeenCalledWith(deviceInfo, expect.any(Function));
     });
   });
 
@@ -232,6 +271,7 @@ describe('EcoFlowAccessoryBase', () => {
       accessory.processQuotaMessage = processQuotaMessageMock;
       mqttApiManagerMock.subscribeOnQuotaTopic.mockResolvedValue(true);
       mqttApiManagerMock.subscribeOnSetReplyTopic.mockResolvedValue(true);
+      mqttApiManagerMock.subscribeOnStatusTopic.mockResolvedValue(true);
 
       await accessory.initialize();
       processQuotaMessage = mqttApiManagerMock.subscribeOnQuotaMessage.mock.calls[0][1]!;
@@ -259,6 +299,7 @@ describe('EcoFlowAccessoryBase', () => {
       jest.spyOn(Math, 'random').mockReturnValue(0.5);
       mqttApiManagerMock.subscribeOnQuotaTopic.mockResolvedValue(true);
       mqttApiManagerMock.subscribeOnSetReplyTopic.mockResolvedValue(true);
+      mqttApiManagerMock.subscribeOnStatusTopic.mockResolvedValue(true);
       await accessory.initialize();
       processSetReplyMessage = mqttApiManagerMock.subscribeOnSetReplyMessage.mock.calls[0][1]!;
     });
@@ -355,15 +396,47 @@ describe('EcoFlowAccessoryBase', () => {
     });
   });
 
+  describe('processStatusMessage', () => {
+    let processStatusMessage: (value: MqttStatusMessage) => void;
+
+    beforeEach(async () => {
+      mqttApiManagerMock.subscribeOnQuotaTopic.mockResolvedValue(true);
+      mqttApiManagerMock.subscribeOnSetReplyTopic.mockResolvedValue(true);
+      mqttApiManagerMock.subscribeOnStatusTopic.mockResolvedValue(true);
+
+      await accessory.initialize();
+      processStatusMessage = mqttApiManagerMock.subscribeOnStatusMessage.mock.calls[0][1]!;
+    });
+
+    it('should update status of all services when status message is received with value Online (1)', async () => {
+      const message = { params: { status: EnableType.On } } as MqttStatusMessage;
+      processStatusMessage(message);
+
+      expect(batteryStatusServiceMock.updateStatus).toHaveBeenCalledWith(true);
+      expect(accessoryInformationServiceMock.updateStatus).toHaveBeenCalledWith(true);
+    });
+
+    it('should update status of all services when status message is received with value Offline (0)', async () => {
+      const message = { params: { status: EnableType.Off } } as MqttStatusMessage;
+      processStatusMessage(message);
+
+      expect(batteryStatusServiceMock.updateStatus).toHaveBeenCalledWith(false);
+      expect(accessoryInformationServiceMock.updateStatus).toHaveBeenCalledWith(false);
+    });
+  });
+
   describe('destroy', () => {
     let quotaSubscriptionMock: jest.Mocked<Subscription>;
     let setReplySubscriptionMock: jest.Mocked<Subscription>;
+    let statusSubscriptionMock: jest.Mocked<Subscription>;
 
     beforeEach(() => {
       quotaSubscriptionMock = { unsubscribe: jest.fn() } as unknown as jest.Mocked<Subscription>;
       setReplySubscriptionMock = { unsubscribe: jest.fn() } as unknown as jest.Mocked<Subscription>;
+      statusSubscriptionMock = { unsubscribe: jest.fn() } as unknown as jest.Mocked<Subscription>;
       mqttApiManagerMock.subscribeOnQuotaMessage.mockReturnValueOnce(quotaSubscriptionMock);
       mqttApiManagerMock.subscribeOnSetReplyMessage.mockReturnValueOnce(setReplySubscriptionMock);
+      mqttApiManagerMock.subscribeOnStatusMessage.mockReturnValueOnce(statusSubscriptionMock);
 
       config.reconnectMqttTimeoutMs = 100;
     });
@@ -382,12 +455,14 @@ describe('EcoFlowAccessoryBase', () => {
     it('should unsubscribe from parameters updates when destroying accessory', async () => {
       mqttApiManagerMock.subscribeOnQuotaTopic.mockResolvedValue(true);
       mqttApiManagerMock.subscribeOnSetReplyTopic.mockResolvedValue(true);
+      mqttApiManagerMock.subscribeOnStatusTopic.mockResolvedValue(true);
       await accessory.initialize();
 
       await accessory.destroy();
 
       expect(quotaSubscriptionMock.unsubscribe).toHaveBeenCalledTimes(1);
       expect(setReplySubscriptionMock.unsubscribe).toHaveBeenCalledTimes(1);
+      expect(statusSubscriptionMock.unsubscribe).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/accessories/glacier/glacierAccessory.spec.ts
+++ b/src/accessories/glacier/glacierAccessory.spec.ts
@@ -247,8 +247,10 @@ describe('GlacierAccessory', () => {
       destroy: jest.fn(),
       subscribeOnQuotaTopic: jest.fn(),
       subscribeOnSetReplyTopic: jest.fn(),
+      subscribeOnStatusTopic: jest.fn(),
       subscribeOnQuotaMessage: jest.fn(),
       subscribeOnSetReplyMessage: jest.fn(),
+      subscribeOnStatusMessage: jest.fn(),
       sendSetCommand: jest.fn(),
     } as unknown as jest.Mocked<EcoFlowMqttApiManager>;
     config = { secretKey: 'secretKey1', accessKey: 'accessKey1', serialNumber: 'sn1' } as unknown as DeviceConfig;
@@ -320,6 +322,7 @@ describe('GlacierAccessory', () => {
       httpApiManagerMock.getAllQuotas.mockResolvedValueOnce(quota);
       mqttApiManagerMock.subscribeOnQuotaTopic.mockResolvedValue(true);
       mqttApiManagerMock.subscribeOnSetReplyTopic.mockResolvedValue(true);
+      mqttApiManagerMock.subscribeOnStatusTopic.mockResolvedValue(true);
     });
 
     describe('updateEmsStatus', () => {

--- a/src/accessories/powerstream/powerStreamAccessory.spec.ts
+++ b/src/accessories/powerstream/powerStreamAccessory.spec.ts
@@ -153,8 +153,10 @@ describe('PowerStreamAccessory', () => {
       destroy: jest.fn(),
       subscribeOnQuotaTopic: jest.fn(),
       subscribeOnSetReplyTopic: jest.fn(),
+      subscribeOnStatusTopic: jest.fn(),
       subscribeOnQuotaMessage: jest.fn(),
       subscribeOnSetReplyMessage: jest.fn(),
+      subscribeOnStatusMessage: jest.fn(),
       sendSetCommand: jest.fn(),
     } as unknown as jest.Mocked<EcoFlowMqttApiManager>;
     batteryStatusProviderMock = {} as jest.Mocked<BatteryStatusProvider>;
@@ -413,6 +415,7 @@ describe('PowerStreamAccessory', () => {
       httpApiManagerMock.getAllQuotas.mockResolvedValueOnce(quota);
       mqttApiManagerMock.subscribeOnQuotaTopic.mockResolvedValue(true);
       mqttApiManagerMock.subscribeOnSetReplyTopic.mockResolvedValue(true);
+      mqttApiManagerMock.subscribeOnStatusTopic.mockResolvedValue(true);
     });
 
     describe('Hearbeat', () => {

--- a/src/accessories/smartplug/smartPlugAccessory.spec.ts
+++ b/src/accessories/smartplug/smartPlugAccessory.spec.ts
@@ -121,8 +121,10 @@ describe('SmartPlugAccessory', () => {
       destroy: jest.fn(),
       subscribeOnQuotaTopic: jest.fn(),
       subscribeOnSetReplyTopic: jest.fn(),
+      subscribeOnStatusTopic: jest.fn(),
       subscribeOnQuotaMessage: jest.fn(),
       subscribeOnSetReplyMessage: jest.fn(),
+      subscribeOnStatusMessage: jest.fn(),
       sendSetCommand: jest.fn(),
     } as unknown as jest.Mocked<EcoFlowMqttApiManager>;
     config = { secretKey: 'secretKey1', accessKey: 'accessKey1', serialNumber: 'sn1' } as unknown as DeviceConfig;
@@ -235,6 +237,7 @@ describe('SmartPlugAccessory', () => {
       httpApiManagerMock.getAllQuotas.mockResolvedValueOnce(quota);
       mqttApiManagerMock.subscribeOnQuotaTopic.mockResolvedValue(true);
       mqttApiManagerMock.subscribeOnSetReplyTopic.mockResolvedValue(true);
+      mqttApiManagerMock.subscribeOnStatusTopic.mockResolvedValue(true);
     });
 
     describe('Hearbeat', () => {

--- a/src/apis/containers/mqttDevice.ts
+++ b/src/apis/containers/mqttDevice.ts
@@ -2,6 +2,7 @@ import {
   MqttMessage,
   MqttQuotaMessage,
   MqttSetReplyMessage,
+  MqttStatusMessage,
   MqttTopicType,
 } from '@ecoflow/apis/interfaces/mqttApiContracts';
 import { DeviceInfoConfig } from '@ecoflow/config';
@@ -11,8 +12,10 @@ import { Observable, Subject, Subscription } from 'rxjs';
 export class MqttDevice {
   private readonly quotaSubject: Subject<MqttQuotaMessage> = new Subject<MqttQuotaMessage>();
   private readonly setReplySubject: Subject<MqttSetReplyMessage> = new Subject<MqttSetReplyMessage>();
+  private readonly statusSubject: Subject<MqttStatusMessage> = new Subject<MqttStatusMessage>();
   private readonly quota$: Observable<MqttQuotaMessage> = this.quotaSubject.asObservable();
   private readonly setReply$: Observable<MqttSetReplyMessage> = this.setReplySubject.asObservable();
+  private readonly status$: Observable<MqttStatusMessage> = this.statusSubject.asObservable();
 
   constructor(
     public config: DeviceInfoConfig,
@@ -28,6 +31,9 @@ export class MqttDevice {
       case MqttTopicType.SetReply:
         this.setReplySubject.next(message as MqttSetReplyMessage);
         break;
+      case MqttTopicType.Status:
+        this.statusSubject.next(message as MqttStatusMessage);
+        break;
       default:
         this.log.warn('Received message for unsupported topic:', topicType);
     }
@@ -42,6 +48,8 @@ export class MqttDevice {
         return this.quota$.subscribe(message => callback(message as TMessage));
       case MqttTopicType.SetReply:
         return this.setReply$.subscribe(message => callback(message as TMessage));
+      case MqttTopicType.Status:
+        return this.status$.subscribe(message => callback(message as TMessage));
       default:
         this.log.warn('Topic is not supported for subscription:', topicType);
         return undefined;

--- a/src/apis/ecoFlowMqttApiManager.ts
+++ b/src/apis/ecoFlowMqttApiManager.ts
@@ -37,6 +37,10 @@ export class EcoFlowMqttApiManager {
     return this.subscribeOnTopic(deviceInfo, MqttTopicType.SetReply);
   }
 
+  public subscribeOnStatusTopic(deviceInfo: DeviceInfo): Promise<boolean> {
+    return this.subscribeOnTopic(deviceInfo, MqttTopicType.Status);
+  }
+
   public subscribeOnQuotaMessage<TMessage>(
     deviceInfo: DeviceInfo,
     callback: (message: TMessage) => void
@@ -49,6 +53,13 @@ export class EcoFlowMqttApiManager {
     callback: (message: TMessage) => void
   ): Subscription | undefined {
     return this.subscribeOnMessage(deviceInfo, MqttTopicType.SetReply, callback);
+  }
+
+  public subscribeOnStatusMessage<TMessage>(
+    deviceInfo: DeviceInfo,
+    callback: (message: TMessage) => void
+  ): Subscription | undefined {
+    return this.subscribeOnMessage(deviceInfo, MqttTopicType.Status, callback);
   }
 
   public async sendSetCommand(deviceInfo: DeviceInfo, message: MqttSetMessage): Promise<void> {

--- a/src/apis/interfaces/mqttApiContracts.ts
+++ b/src/apis/interfaces/mqttApiContracts.ts
@@ -1,6 +1,17 @@
+import { EnableType } from '@ecoflow/characteristics/characteristicContracts';
+
 export interface MqttMessage {}
 
 export interface MqttQuotaMessage extends MqttMessage {}
+
+export interface MqttStatusMessage extends MqttMessage {
+  id: string;
+  version: string;
+  timestamp: number;
+  params: {
+    status: EnableType;
+  };
+}
 
 export interface MqttQuotaMessageWithParams<TParams> extends MqttQuotaMessage {
   params: TParams;
@@ -49,4 +60,5 @@ export interface MqttSetReplyMessageWithData<TData extends MqttSetReplyMessageDa
 export enum MqttTopicType {
   Quota = 'quota',
   SetReply = 'set_reply',
+  Status = 'status',
 }

--- a/src/services/serviceBase.ts
+++ b/src/services/serviceBase.ts
@@ -49,6 +49,11 @@ export abstract class ServiceBase {
     }
   }
 
+  public updateStatus(online: boolean): void {
+    this.log.debug(`[${this.serviceName}] Device is ${online ? 'online' : 'offline'}`);
+    this.service.updateCharacteristic(this.platform.Characteristic.StatusActive, online);
+  }
+
   protected get serviceName(): string {
     return this.ecoFlowAccessory.config.name + (this.serviceSubType ? ` ${this.serviceSubType}` : '');
   }

--- a/src/services/switchServiceBase.spec.ts
+++ b/src/services/switchServiceBase.spec.ts
@@ -161,6 +161,31 @@ describe('SwitchServiceBase', () => {
     });
   });
 
+  describe('updateStatus', () => {
+    beforeEach(() => {
+      accessoryMock.getServiceById.mockReturnValueOnce(hapService);
+      service.initialize();
+    });
+
+    it('should set StatusActive to false when device is offline', () => {
+      service.updateStatus(false);
+
+      const actual = service.service.getCharacteristic(HapCharacteristic.StatusActive).value;
+
+      expect(actual).toBeFalsy();
+      expect(logMock.debug.mock.calls).toEqual([['[accessory1 X-Boost] Device is offline']]);
+    });
+
+    it('should set StatusActive to true when device is online', () => {
+      service.updateStatus(true);
+
+      const actual = service.service.getCharacteristic(HapCharacteristic.StatusActive).value;
+
+      expect(actual).toBeTruthy();
+      expect(logMock.debug.mock.calls).toEqual([['[accessory1 X-Boost] Device is online']]);
+    });
+  });
+
   describe('processOnSetOn', () => {
     let characteristic: Characteristic;
     beforeEach(() => {


### PR DESCRIPTION
Make sure that the pull request meets DoD criteria:

_Documentation_

- [ ] Changes that makes documentation outdated are described in `README.md`

_Maintainability_

- [ ] Reasonable amount of logging has been added (`Debug` level)
- [ ] All errors are logged with `Error` level
- [ ] Validation errors are logged with `Warning` level

_Testing_

- [ ] Plugin does not crash when configuration is not provided (default state)
- [ ] New functionality is dev tested in `Homebridge`
- [ ] Errors that are produced by plugin do not crash `Homebridge`

- Features
    - Resolves #38
       - When device is reported to be offline, mark device as "non responsive" in HomeKit
       - When device is reported to be online, mark device as active in HomeKit
