### PR TITLE
Use minimum supported Node.js for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,10 +34,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Use Node.js 24.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: 24.x
+          node-version: 18.x
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update package version


### PR DESCRIPTION
Make sure that the pull request meets DoD criteria:

_Documentation_

- [x] Changes that makes documentation outdated are described in `README.md`

_Maintainability_

- [x] Reasonable amount of logging has been added (`Debug` level)
- [x] All errors are logged with `Error` level
- [x] Validation errors are logged with `Warning` level

_Testing_

- [x] Plugin does not crash when configuration is not provided (default state)
- [x] New functionality is dev tested in `Homebridge`
- [x] Errors that are produced by plugin do not crash `Homebridge`

Changes:
- Use minumum supported version on node.js (18.x) in `publish` workflow